### PR TITLE
Update prepare_trinity_genome_assembly_pbs.pl

### DIFF
--- a/bin/prepare_trinity_genome_assembly_pbs.pl
+++ b/bin/prepare_trinity_genome_assembly_pbs.pl
@@ -74,7 +74,7 @@ pod2usage $! unless &GetOptions(
 	'medium_cutoff:i' => \$medium_cut,
 	'sam:s{,}'   => \@user_provided_sam_files,
 	'bam|files_bam:s{,}' => \@user_provided_bam_files,
-	'intron_max:i'   => $intron_max_size,
+	'intron_max:i'   => \$intron_max_size,
 	'single_stranded:s' => \$is_single_stranded,
 	'single_end' => \$single_end,
 	'split_scaffolds' => \$do_split_scaffolds,


### PR DESCRIPTION
Otherwise default $intron_max_size overwrites the input script argument.