### PR TITLE
Update align_rnaseq_gsnap.pl

### DIFF
--- a/bin/align_rnaseq_gsnap.pl
+++ b/bin/align_rnaseq_gsnap.pl
@@ -523,7 +523,7 @@ sub align_paired_files() {
   $file_align_cmd .= ' --gunzip ' if $file =~ /\.gz$/; 
   $file_align_cmd .= $qual_prot if $qual_prot;
 
-  $file_align_cmd .=    " --split-output=gsnap.$base --read-group-id=$base $file $pair ";
+  $file_align_cmd .=    " --split-output=gsnap.$base --read-group-id=$base --allow-pe-name-mismatch $file $pair ";
   &process_cmd( $file_align_cmd, '.', "gsnap.$base*" )    unless (    -s "$base_out_filename"."_uniq" || -s "$base_out_filename"."_uniq.bam" );
 
   unless ( -s "$base_out_filename"."_uniq.bam" || $just_write_out_commands) {


### PR DESCRIPTION
Without this flag, processing of input files containing filtered reads than could have no pair, result in error in GSNAP call. This error is similar to [this one](https://www.biostars.org/p/203212/).